### PR TITLE
Yosegi-46 jackson and jetty security alerts

### DIFF
--- a/docker/logging_server/source/pom.xml
+++ b/docker/logging_server/source/pom.xml
@@ -30,12 +30,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.15.v20190215</version>
+      <version>9.4.17.v20190418</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.15.v20190215</version>
+      <version>9.4.17.v20190418</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/etc/dependency_pom.xml.template
+++ b/etc/dependency_pom.xml.template
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <version>2.7.1</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/etc/dependency_pom.xml.template
+++ b/etc/dependency_pom.xml.template
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-metastore</artifactId>
-      <version>1.2.1000.2.6.2.0-205</version>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
@@ -33,17 +33,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
-      <version>1.2.1000.2.6.4.0-91</version>
+      <version>3.1.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -113,18 +113,18 @@
     <dependency>
       <groupId>jp.co.yahoo.yosegi</groupId>
       <artifactId>yosegi-hive</artifactId>
-      <version>0.9.0</version>
+      <version>0.10.0_hive-3.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -160,14 +160,6 @@
   </dependencies>
 
   <repositories>
-    <repository>
-      <id>hdp</id>
-      <url> http://repo.hortonworks.com/content/repositories/releases</url>
-      <name>HDP</name>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
     <repository>
       <id>spring</id>
       <url>http://repo.spring.io/plugins-release/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -80,19 +80,19 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <version>2.7.3</version>
+      <version>3.2.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
-      <artifactId>hive-exec</artifactId>
+      <artifactId>hive-metastore</artifactId>
       <version>3.1.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
-      <version>0.11.0</version>
+      <version>0.9.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Upgraded for security alert.
Competed with Arrow in Hive's security alert support.

https://github.com/apache/arrow/pull/2515

The Apache Arrow version has been downgraded to 0.9.0 for tools compilation.

### How did you do the test? (Not required for updating documents)
The version has been upgraded, but there is no problem with compilation and unit testing.


