### PR TITLE
fix tool which is get yosegi related jars.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 .settings/
 .classpath
 .project
+.yosegi
 test-output/
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -110,7 +110,7 @@ function get_jars() {
 }
 
 
-yosegi_source=$SCRIPT_DIR/yosegi_deliver/version.sh
+yosegi_source=$SCRIPT_DIR/yosegi_deliver/versions.sh
 while getopts i:l:h OPT
 do
   case $OPT in

--- a/bin/yosegi_deliver/versions.sh.template
+++ b/bin/yosegi_deliver/versions.sh.template
@@ -1,5 +1,5 @@
-yosegi=0.9.0.1
-yosegi-hive=0.9.0
-yosegi-hadoop=0.9.0
-yosegi-avro=0.9.0
-yosegi-legacy=0.9.0
+yosegi=0.10.0
+yosegi_hive=0.9.0
+yosegi_hadoop=0.9.0
+yosegi_avro=0.9.0
+yosegi_legacy=0.9.0


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
fix the bugs of the tool for getting Yosegi jars.

### How did you do the test? (Not required for updating documents)
I tested using the tool and test to create yosegi file and read under Hive correctly.