### PR TITLE
Change for sonatype usertoken

### DIFF
--- a/.circleci/.maven.xml
+++ b/.circleci/.maven.xml
@@ -4,8 +4,8 @@
         <server>
             <!-- Maven Central Deployment -->
             <id>ossrh</id>
-            <username>${env.SONATYPE_USERNAME}</username>
-            <password>${env.SONATYPE_PASSWORD}</password>
+            <username>${env.SONATYPE_USERTOKEN_ID}</username>
+            <password>${env.SONATYPE_USERTOKEN_TOKEN}</password>
         </server>
     </servers>
 </settings>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   limitations under the License. See accompanying LICENSE file.
 -->
 
-# Yosegi Hive
+# Yosegi Tools
 This is [Yosegi](https://github.com/yahoojapan/yosegi) tools.
 
 # License


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Using sonatype usertoken is required for uploading maven central.

### How did you do the test? (Not required for updating documents)
In this PR.